### PR TITLE
Refs #31009 - drop LookupKeysHelper puppet methods

### DIFF
--- a/app/helpers/lookup_keys_helper.rb
+++ b/app/helpers/lookup_keys_helper.rb
@@ -179,10 +179,4 @@ module LookupKeysHelper
     return 'host' if params.has_key?(:host) || params[:controller] == 'hosts'
     'hostgroup'
   end
-
-  def lookup_keys_breadcrumbs
-    breadcrumbs(resource_url: "/api/v2/smart_class_parameters",
-                name_field: "parameter",
-                switcher_item_url: "/puppetclass_lookup_keys/:id-:name/edit")
-  end
 end


### PR DESCRIPTION
Forgotten PuppetclassLookupKeyHelper.

Extracted in https://github.com/theforeman/foreman_puppet_enc/pull/43.