### PR TITLE
Refs #31062 - drop Environments from Host API

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -19,7 +19,7 @@ module Api
 
       add_scope_for(:index) do |base_scope|
         base_scope.preload([:host_statuses, :compute_resource, :hostgroup, :operatingsystem,
-                            :interfaces, :token, :owner, :model, :environment, :location,
+                            :interfaces, :token, :owner, :model, :location,
                             :organization, :image, :compute_profile, :realm, :architecture,
                             :ptable, :medium, :puppet_proxy, :puppet_ca_proxy])
       end
@@ -28,12 +28,10 @@ module Api
       api :GET, "/hostgroups/:hostgroup_id/hosts", N_("List all hosts for a host group")
       api :GET, "/locations/:location_id/hosts", N_("List hosts per location")
       api :GET, "/organizations/:organization_id/hosts", N_("List hosts per organization")
-      api :GET, "/environments/:environment_id/hosts", N_("List hosts per environment")
       param :thin, :bool, :desc => N_("Only list ID and name of hosts")
       param :hostgroup_id, String, :desc => N_("ID of host group")
       param :location_id, String, :desc => N_("ID of location")
       param :organization_id, String, :desc => N_("ID of organization")
-      param :environment_id, String, :desc => N_("ID of environment")
       param :include, ['parameters', 'all_parameters'], :desc => N_("Array of extra information types to include")
       param_group :search_and_pagination, ::Api::V2::BaseController
       add_scoped_search_description_for(Host)
@@ -71,7 +69,6 @@ module Api
           param :name, String, :required => true
           param :location_id, :number, :required => true
           param :organization_id, :number, :required => true
-          param :environment_id, String, :desc => N_("required if host is managed and value is not inherited from host group")
           param :ip, String, :desc => N_("not required if using a subnet with DHCP proxy")
           param :mac, String, :desc => N_("required for managed host that is bare metal, not required if it's a virtual machine")
           param :architecture_id, :number, :desc => N_("required if host is managed and value is not inherited from host group")
@@ -424,7 +421,7 @@ module Api
       end
 
       def allowed_nested_id
-        %w(hostgroup_id location_id organization_id environment_id)
+        %w(hostgroup_id location_id organization_id)
       end
 
       def resource_class_join(association, scope)

--- a/app/views/api/v2/hosts/main.json.rabl
+++ b/app/views/api/v2/hosts/main.json.rabl
@@ -8,7 +8,7 @@ extends "api/v2/smart_proxies/children_nodes"
 @object.configuration_status(:last_reports => @last_reports)
 @object.configuration_status_label(:last_reports => @last_reports)
 
-attributes :ip, :ip6, :environment_id, :environment_name, :last_report, :mac, :realm_id, :realm_name,
+attributes :ip, :ip6, :last_report, :mac, :realm_id, :realm_name,
   :sp_mac, :sp_ip, :sp_name, :domain_id, :domain_name, :architecture_id, :architecture_name, :operatingsystem_id, :operatingsystem_name,
   :subnet_id, :subnet_name, :subnet6_id, :subnet6_name, :sp_subnet_id, :ptable_id, :ptable_name, :medium_id, :medium_name, :pxe_loader,
   :build, :comment, :disk, :installed_at, :model_id, :hostgroup_id, :owner_id, :owner_name, :owner_type,


### PR DESCRIPTION
Drops notion of Environments from Host API.

Extracted in theforeman/foreman_puppet_enc#50