### PR TITLE
Refs #31094 - drop config_groups from Host(group) API

### DIFF
--- a/app/views/api/v2/hostgroups/show.json.rabl
+++ b/app/views/api/v2/hostgroups/show.json.rabl
@@ -14,10 +14,6 @@ node do |hostgroup|
   { :all_puppetclasses => partial("api/v2/puppetclasses/base", :object => hostgroup.all_puppetclasses) }
 end
 
-child :config_groups do
-  extends "api/v2/config_groups/main"
-end
-
 node do |hostgroup|
   partial("api/v2/taxonomies/children_nodes", :object => hostgroup)
 end

--- a/app/views/api/v2/hosts/show.json.rabl
+++ b/app/views/api/v2/hosts/show.json.rabl
@@ -14,10 +14,6 @@ node do |host|
   { :all_puppetclasses => partial("api/v2/puppetclasses/base", :object => host.all_puppetclasses) }
 end
 
-child :config_groups do
-  extends "api/v2/config_groups/main"
-end
-
 root_object.facets_with_definitions.each do |_facet, definition|
   node do
     partial(definition.api_single_view, :object => root_object) if definition.api_single_view


### PR DESCRIPTION
Drops config_groups node from Host and Hostgroup API responses.

Extracted in https://github.com/theforeman/foreman_puppet_enc/pull/66.