### PR TITLE
Fixes #31732 - drop environment in TemplateCombination model

### DIFF
--- a/app/controllers/api/v2/template_combinations_controller.rb
+++ b/app/controllers/api/v2/template_combinations_controller.rb
@@ -69,7 +69,7 @@ module Api
       private
 
       def allowed_nested_id
-        %w(environment_id hostgroup_id provisioning_template_id)
+        %w(hostgroup_id provisioning_template_id)
       end
     end
   end

--- a/app/models/concerns/hostext/operating_system.rb
+++ b/app/models/concerns/hostext/operating_system.rb
@@ -14,7 +14,6 @@ module Hostext
       opts[:kind]               ||= "provision"
       opts[:operatingsystem_id] ||= operatingsystem_id
       opts[:hostgroup_id]       ||= hostgroup_id
-      opts[:environment_id]     ||= environment_id
 
       Taxonomy.as_taxonomy(organization, location) do
         ProvisioningTemplate.find_template opts
@@ -27,7 +26,6 @@ module Hostext
         ProvisioningTemplate.find_template({ :kind               => kind.name,
                                              :operatingsystem_id => operatingsystem_id,
                                              :hostgroup_id       => hostgroup_id,
-                                             :environment_id     => environment_id,
         })
       end.compact
     end

--- a/app/models/provisioning_template.rb
+++ b/app/models/provisioning_template.rb
@@ -21,13 +21,12 @@ class ProvisioningTemplate < Template
   validates :name, :uniqueness => true
   validates :template_kind_id, :presence => true, :unless => proc { |t| t.snippet }
 
-  before_destroy EnsureNotUsedBy.new(:hostgroups, :environments, :os_default_templates)
+  before_destroy EnsureNotUsedBy.new(:hostgroups, :os_default_templates)
   has_many :template_combinations, :dependent => :destroy
   has_many :hostgroups, :through => :template_combinations
-  has_many :environments, :through => :template_combinations
   belongs_to :template_kind
   accepts_nested_attributes_for :template_combinations, :allow_destroy => true,
-    :reject_if => ->(tc) { tc[:environment_id].blank? && tc[:hostgroup_id].blank? }
+    :reject_if => :reject_template_combination_attributes?
   has_and_belongs_to_many :operatingsystems, :join_table => :operatingsystems_provisioning_templates, :association_foreign_key => :operatingsystem_id, :foreign_key => :provisioning_template_id
   has_many :os_default_templates
   before_save :check_for_snippet_assoications
@@ -44,7 +43,6 @@ class ProvisioningTemplate < Template
   scoped_search :on => :default, :only_explicit => true, :complete_value => {:true => true, :false => false}, :rename => 'default_template'
 
   scoped_search :relation => :operatingsystems, :on => :name, :rename => :operatingsystem, :complete_value => true
-  scoped_search :relation => :environments,     :on => :name, :rename => :environment,     :complete_value => true
   scoped_search :relation => :hostgroups,       :on => :name, :rename => :hostgroup,       :complete_value => true
   scoped_search :relation => :template_kind,    :on => :name, :rename => :kind,            :complete_value => true
 
@@ -74,16 +72,22 @@ class ProvisioningTemplate < Template
   def self.template_ids_for(hosts)
     hosts = hosts.with_os.distinct
     oses = hosts.pluck(:operatingsystem_id)
-    hostgroups = hosts.pluck(:hostgroup_id) | [nil]
-    environments = hosts.pluck(:environment_id) | [nil]
     templates = ProvisioningTemplate.reorder(nil).joins(:operatingsystems, :template_kind).where('operatingsystems.id' => oses, 'template_kinds.name' => 'provision')
-    ids = templates.joins(:template_combinations).where("template_combinations.hostgroup_id" => hostgroups, "template_combinations.environment_id" => environments).distinct.pluck(:id)
+    ids = templates_by_template_combinations(templates, hosts).pluck(:id)
     ids += templates.joins(:os_default_templates).where("os_default_templates.operatingsystem_id" => oses).distinct.pluck(:id)
     ids.uniq
   end
 
+  def self.templates_by_template_combinations(templates, hosts_or_conditions)
+    conditions = hosts_or_conditions
+    unless hosts_or_conditions.is_a?(Hash)
+      conditions = { hostgroup_id: hosts_or_conditions.pluck(:hostgroup_id) | [nil] }
+    end
+    templates.joins(:template_combinations).where("template_combinations.hostgroup_id" => conditions[:hostgroup_id]).distinct
+  end
+
   def self.template_includes
-    super + [:template_kind, :template_combinations => [:hostgroup, :environment]]
+    super + [:template_kind, :template_combinations => [:hostgroup]]
   end
 
   def self.default_render_scope_class
@@ -101,29 +105,8 @@ class ProvisioningTemplate < Template
 
     # first filter valid templates to our OS and requested template kind.
     templates = ProvisioningTemplate.joins(:operatingsystems, :template_kind).where('operatingsystems.id' => opts[:operatingsystem_id], 'template_kinds.name' => opts[:kind])
-
     # once a template has been matched, we no longer look for others.
-
-    if opts[:hostgroup_id] && opts[:environment_id]
-      # try to find a full match to our host group and environment
-      template ||= templates.joins(:template_combinations).find_by(
-        "template_combinations.hostgroup_id" => opts[:hostgroup_id],
-        "template_combinations.environment_id" => opts[:environment_id])
-    end
-
-    if opts[:hostgroup_id]
-      # try to find a match with our hostgroup only
-      template ||= templates.joins(:template_combinations).find_by(
-        "template_combinations.hostgroup_id" => opts[:hostgroup_id],
-        "template_combinations.environment_id" => nil)
-    end
-
-    if opts[:environment_id]
-      # search for a template based only on our environment
-      template ||= templates.joins(:template_combinations).find_by(
-        "template_combinations.hostgroup_id" => nil,
-        "template_combinations.environment_id" => opts[:environment_id])
-    end
+    template = templates_by_template_combinations(templates, opts).first
 
     # fall back to the os default template
     template ||= templates.joins(:os_default_templates).find_by("os_default_templates.operatingsystem_id" => opts[:operatingsystem_id])
@@ -206,7 +189,7 @@ class ProvisioningTemplate < Template
   # generated for
   def self.pxe_default_combos
     combos = []
-    ProvisioningTemplate.joins(:template_kind).where("template_kinds.name" => "provision").includes(:template_combinations => [:environment, {:hostgroup => [:operatingsystem, :architecture]}]).find_each do |template|
+    ProvisioningTemplate.joins(:template_kind).where("template_kinds.name" => "provision").includes(:template_combinations => [{:hostgroup => [:operatingsystem, :architecture]}]).find_each do |template|
       template.template_combinations.each do |combination|
         hostgroup = combination.hostgroup
         if hostgroup&.operatingsystem && hostgroup&.architecture
@@ -263,9 +246,12 @@ class ProvisioningTemplate < Template
   def check_for_snippet_assoications
     return unless snippet
     hostgroups.clear
-    environments.clear
     template_combinations.clear
     operatingsystems.clear
     self.template_kind = nil
+  end
+
+  def reject_template_combination_attributes?(params)
+    params[:hostgroup_id].blank?
   end
 end

--- a/app/models/template_combination.rb
+++ b/app/models/template_combination.rb
@@ -1,8 +1,6 @@
 class TemplateCombination < ApplicationRecord
   belongs_to :provisioning_template
-  belongs_to :environment
   belongs_to :hostgroup
 
-  validates :environment_id, :uniqueness => {:scope => [:hostgroup_id, :provisioning_template_id]}
-  validates :hostgroup_id, :uniqueness => {:scope => [:environment_id, :provisioning_template_id]}
+  validates :hostgroup_id, :uniqueness => {:scope => [:provisioning_template_id]}
 end

--- a/db/migrate/20101121135521_create_template_combinations.rb
+++ b/db/migrate/20101121135521_create_template_combinations.rb
@@ -3,7 +3,6 @@ class CreateTemplateCombinations < ActiveRecord::Migration[4.2]
     create_table :template_combinations do |t|
       t.references :config_template
       t.references :hostgroup
-      t.references :environment
 
       t.timestamps null: true
     end

--- a/db/migrate/20130908100439_delete_orphaned_records.rb
+++ b/db/migrate/20130908100439_delete_orphaned_records.rb
@@ -52,7 +52,6 @@ class DeleteOrphanedRecords < ActiveRecord::Migration[4.2]
     OsDefaultTemplate.where("operatingsystem_id NOT IN (?)", Operatingsystem.unscoped.pluck(:id)).update_all(:operatingsystem_id => nil)
     OsDefaultTemplate.where("template_kind_id NOT IN (?)", TemplateKind.unscoped.pluck(:id)).update_all(:template_kind_id => nil)
     TemplateCombination.where("config_template_id NOT IN (?)", FakeConfigTemplate.unscoped.pluck(:id)).update_all(:config_template_id => nil)
-    TemplateCombination.where("environment_id NOT IN (?)", Environment.unscoped.pluck(:id)).update_all(:environment_id => nil)
     TemplateCombination.where("hostgroup_id NOT IN (?)", Hostgroup.unscoped.pluck(:id)).update_all(:hostgroup_id => nil)
 
     host_groups_up

--- a/db/migrate/20130908170524_add_keys.rb
+++ b/db/migrate/20130908170524_add_keys.rb
@@ -72,7 +72,6 @@ class AddKeys < ActiveRecord::Migration[4.2]
     add_foreign_key "subnets", "smart_proxies", :name => "subnets_tftp_id_fk", :column => "tftp_id"
     add_foreign_key "taxable_taxonomies", "taxonomies", :name => "taxable_taxonomies_taxonomy_id_fk"
     add_foreign_key "template_combinations", "config_templates", :name => "template_combinations_config_template_id_fk"
-    add_foreign_key "template_combinations", "environments", :name => "template_combinations_environment_id_fk"
     add_foreign_key "template_combinations", "hostgroups", :name => "template_combinations_hostgroup_id_fk"
     add_foreign_key "tokens", "hosts", :name => "tokens_host_id_fk"
     add_foreign_key "user_compute_resources", "compute_resources", :name => "user_compute_resources_compute_resource_id_fk"

--- a/test/controllers/api/v2/template_combinations_controller_test.rb
+++ b/test/controllers/api/v2/template_combinations_controller_test.rb
@@ -34,11 +34,12 @@ class Api::V2::TemplateCombinationsControllerTest < ActionController::TestCase
     end
 
     test "should update template combination" do
-      put :update, params: { :template_combination => { :hostgroup_id => hostgroups(:common).id },
+      new_hg = FactoryBot.create(:hostgroup)
+      put :update, params: { :template_combination => { :hostgroup_id => new_hg.id },
                              :provisioning_template_id => templates(:mystring2).id, :id => template_combinations(:two).id }
 
       template_combination = ActiveSupport::JSON.decode(@response.body)
-      assert_equal(template_combination["hostgroup_id"], hostgroups(:common).id)
+      assert_equal(template_combination["hostgroup_id"], new_hg.id)
       assert_response :success
     end
 

--- a/test/controllers/provisioning_templates_controller_test.rb
+++ b/test/controllers/provisioning_templates_controller_test.rb
@@ -150,9 +150,9 @@ class ProvisioningTemplatesControllerTest < ActionController::TestCase
     end
 
     test "pxe menu's labels should be sorted" do
-      t1 = TemplateCombination.new :hostgroup => hostgroups(:db), :environment => environments(:production)
+      t1 = TemplateCombination.new :hostgroup => hostgroups(:db)
       t1.provisioning_template = templates(:mystring2)
-      t2 = TemplateCombination.new :hostgroup => hostgroups(:common), :environment => environments(:production)
+      t2 = TemplateCombination.new :hostgroup => hostgroups(:common)
       t2.provisioning_template = templates(:mystring2)
       t1.save
       t2.save
@@ -162,7 +162,7 @@ class ProvisioningTemplatesControllerTest < ActionController::TestCase
     end
 
     test "kickstart url should support in nested hostgroup " do
-      t1 = TemplateCombination.new :hostgroup => hostgroups(:inherited), :environment => environments(:production)
+      t1 = TemplateCombination.new :hostgroup => hostgroups(:inherited)
       t1.provisioning_template = templates(:mystring2)
       t1.save
       ProxyAPI::TFTP.any_instance.expects(:create_default).with(regexp_matches(/^PXE.*/), has_entry(:menu, regexp_matches(/ks=http:\/\/foreman.unattended.url\/unattended\/template\/MyString2\/Parent\/inherited/))).returns(true).times(3)

--- a/test/factories/provisioning_template.rb
+++ b/test/factories/provisioning_template.rb
@@ -20,7 +20,6 @@ FactoryBot.define do
   factory :template_combination do
     provisioning_template
     hostgroup
-    environment
   end
 
   factory :os_default_template do

--- a/test/fixtures/template_combinations.yml
+++ b/test/fixtures/template_combinations.yml
@@ -2,7 +2,6 @@
 one:
   provisioning_template: mystring
   hostgroup: common
-  environment: production
 
 two:
   provisioning_template: mystring2
@@ -15,9 +14,7 @@ three:
 four:
   provisioning_template: mystring2
   hostgroup: common
-  environment: production
 
 five:
   provisioning_template: myscript
   hostgroup: common
-  environment: production

--- a/test/models/concerns/hostext/operating_system_test.rb
+++ b/test/models/concerns/hostext/operating_system_test.rb
@@ -7,8 +7,7 @@ module Hostext
         @host = Host.create(:name => "host.mydomain.net", :mac => "aabbccddeaff",
                             :ip => "2.3.04.03",           :medium => media(:one),
                             :subnet => subnets(:one), :hostgroup => Hostgroup.find_by_name("Common"),
-                            :architecture => Architecture.find_by(name: 'x86_64'), :disk => "aaa",
-                            :environment => Environment.find_by_name("production"))
+                            :architecture => Architecture.find_by(name: 'x86_64'), :disk => "aaa")
       end
 
       test "retrieves iPXE template if associated to the correct env and host group" do

--- a/test/models/concerns/taxonomix_test.rb
+++ b/test/models/concerns/taxonomix_test.rb
@@ -290,7 +290,7 @@ class TaxonomixTest < ActiveSupport::TestCase
     in_taxonomy org do
       as_user user do
         assert_nothing_raised do
-          ProvisioningTemplate.includes([:template_combinations => [:hostgroup, :environment]]).search_for('something').first
+          ProvisioningTemplate.includes([:template_combinations => :hostgroup]).search_for('something').first
         end
       end
     end

--- a/test/models/provisioning_template_test.rb
+++ b/test/models/provisioning_template_test.rb
@@ -31,13 +31,11 @@ class ProvisioningTemplateTest < ActiveSupport::TestCase
     tmplt.template_kind = template_kinds(:finish)
     tmplt.snippet = false # this is the default, but it helps show the case
     tmplt.hostgroups << hostgroups(:common)
-    tmplt.environments << environments(:production)
     as_admin do
       assert tmplt.save
     end
     assert_equal template_kinds(:finish), tmplt.template_kind
     assert_equal [hostgroups(:common)], tmplt.hostgroups
-    assert_equal [environments(:production)], tmplt.environments
   end
 
   test "should not save assoications if snippet" do
@@ -47,13 +45,11 @@ class ProvisioningTemplateTest < ActiveSupport::TestCase
     tmplt.snippet  = true
     tmplt.template_kind = template_kinds(:ipxe)
     tmplt.hostgroups << hostgroups(:common)
-    tmplt.environments << environments(:production)
     as_admin do
       assert tmplt.save
     end
     assert_nil tmplt.template_kind
     assert_equal [], tmplt.hostgroups
-    assert_equal [], tmplt.environments
     assert_equal [], tmplt.template_combinations
   end
 
@@ -183,31 +179,13 @@ class ProvisioningTemplateTest < ActiveSupport::TestCase
       medium = FactoryBot.create(:medium, :name => "combo_medium", :path => "http://www.example.com/m")
       @os1 = FactoryBot.create(:rhel7_5, :media => [medium], :architectures => [@arch])
       @hg1 = FactoryBot.create(:hostgroup, :name => "hg1", :operatingsystem => @os1, :architecture => @arch, :medium => @os1.media.first)
-      @hg2 = FactoryBot.create(:hostgroup, :name => "hg2", :operatingsystem => @os1, :architecture => @arch)
-      @hg3 = FactoryBot.create(:hostgroup, :name => "hg3", :operatingsystem => @os1, :architecture => @arch)
-      @ev1 = FactoryBot.create(:environment, :name => "env1")
-      @ev2 = FactoryBot.create(:environment, :name => "env2")
-      @ev3 = FactoryBot.create(:environment, :name => "env3")
-
+      @hg2 = FactoryBot.create(:hostgroup, :name => "hg2", :operatingsystem => @os1, :architecture => @arch, :medium => @os1.media.first)
       @tk = TemplateKind.find_by_name('provision')
 
-      # Most specific template association
-      @ct1 = FactoryBot.create(:provisioning_template, :name => "ct1", :template_kind => @tk, :operatingsystems => [@os1])
-      @ct1.template_combinations.create(:hostgroup => @hg1, :environment => @ev1)
-
       # HG only
-      # We add an association on HG2/EV2 to ensure that we're not just blindly
-      # selecting all template_combinations where environment_id => nil
-      @ct2 = FactoryBot.create(:provisioning_template, :name => "ct2", :template_kind => @tk, :operatingsystems => [@os1])
-      @ct2.template_combinations.create(:hostgroup => @hg1, :environment => nil)
-      @ct2.template_combinations.create(:hostgroup => @hg2, :environment => @ev2)
-
-      # Env only
-      # We add an association on HG2/EV2 to ensure that we're not just blindly
-      # selecting all template_combinations where hostgroup_id => nil
-      @ct3 = FactoryBot.create(:provisioning_template, :name => "ct3", :template_kind => @tk, :operatingsystems => [@os1])
-      @ct3.template_combinations.create(:hostgroup => nil, :environment => @ev1)
-      @ct3.template_combinations.create(:hostgroup => @hg2, :environment => @ev2)
+      # Most specific template association that has left after puppet env extraction
+      @ct1 = FactoryBot.create(:provisioning_template, :name => "ct1", :template_kind => @tk, :operatingsystems => [@os1])
+      @ct1.template_combinations.create(:hostgroup => @hg1)
 
       # Default template for the OS
       @ctd = FactoryBot.create(:provisioning_template, :name => "ctd", :template_kind => @tk, :operatingsystems => [@os1])
@@ -224,56 +202,16 @@ class ProvisioningTemplateTest < ActiveSupport::TestCase
       p1 = Foreman::Plugin.medium_providers_registry.find_provider(@hg1)
       refute_nil p1
       assert_empty p1.validate
-
-      p2 = Foreman::Plugin.medium_providers_registry.find_provider(@hg2)
-      refute_nil p2
-      assert_empty p2.validate
     end
 
     test "find_template finds a matching template with hg and env" do
       assert_equal @ct1.name,
-        ProvisioningTemplate.find_template({:kind => @tk.name,
-                                      :operatingsystem_id => @os1.id,
-                                      :hostgroup_id => @hg1.id,
-                                      :environment_id => @ev1.id}).name
+        ProvisioningTemplate.find_template(kind: @tk.name, operatingsystem_id: @os1.id, hostgroup_id: @hg1.id).name
     end
 
-    test "find_template finds a matching template with hg only" do
-      assert_equal @ct2.name,
-        ProvisioningTemplate.find_template({:kind => @tk.name,
-                                      :operatingsystem_id => @os1.id,
-                                      :hostgroup_id => @hg1.id}).name
-    end
-
-    test "find_template finds a matching template with hg and mismatched env" do
-      assert_equal @ct2.name,
-        ProvisioningTemplate.find_template({:kind => @tk.name,
-                                      :operatingsystem_id => @os1.id,
-                                      :hostgroup_id => @hg1.id,
-                                      :environment_id => @ev3.id}).name
-    end
-
-    test "find_template finds a matching template with env only" do
-      assert_equal @ct3.name,
-        ProvisioningTemplate.find_template({:kind => @tk.name,
-                                      :operatingsystem_id => @os1.id,
-                                      :environment_id => @ev1.id}).name
-    end
-
-    test "find_template finds a matching template with env and mismatched hg" do
-      assert_equal @ct3.name,
-        ProvisioningTemplate.find_template({:kind => @tk.name,
-                                      :operatingsystem_id => @os1.id,
-                                      :hostgroup_id => @hg3.id,
-                                      :environment_id => @ev1.id}).name
-    end
-
-    test "find_template finds the default template when hg and env do not match" do
+    test "find_template finds the default template when hg do not match" do
       assert_equal @ctd.name,
-        ProvisioningTemplate.find_template({:kind => @tk.name,
-                                      :operatingsystem_id => @os1.id,
-                                      :hostgroup_id => @hg3.id,
-                                      :environment_id => @ev3.id}).name
+        ProvisioningTemplate.find_template(kind: @tk.name, operatingsystem_id: @os1.id, hostgroup_id: @hg2.id).name
     end
 
     test "pxe_default_combos should return valid combinations" do
@@ -288,9 +226,9 @@ class ProvisioningTemplateTest < ActiveSupport::TestCase
         global_template_name = ProvisioningTemplate.global_template_name_for(kind)
         default_template = ProvisioningTemplate.find_global_default_template(global_template_name, kind)
         expected = {}
-        expected["PXELinux"] = [/combo_medium-[A-Za-z0-9_=]+-(vmlinuz|initrd.img)/, /LABEL hg1 - ct[12]/, /LABEL hg2 - ct[23]/]
-        expected["PXEGrub"] = [/combo_medium-[A-Za-z0-9_=]+-(vmlinuz|initrd.img)/, /title hg1 - ct[12]/, /title hg2 - ct[23]/]
-        expected["PXEGrub2"] = [/combo_medium-[A-Za-z0-9_=]+-(vmlinuz|initrd.img)/, /hg1 - ct[12]/, /hg2 - ct[23]/]
+        expected["PXELinux"] = [/combo_medium-[A-Za-z0-9_=]+-(vmlinuz|initrd.img)/, /LABEL hg1 - ct1/]
+        expected["PXEGrub"] = [/combo_medium-[A-Za-z0-9_=]+-(vmlinuz|initrd.img)/, /title hg1 - ct1/]
+        expected["PXEGrub2"] = [/combo_medium-[A-Za-z0-9_=]+-(vmlinuz|initrd.img)/, /hg1 - ct1/]
         expected[kind].each do |match|
           assert_match match, default_template.render(variables: { profiles: ProvisioningTemplate.pxe_default_combos })
         end
@@ -305,10 +243,10 @@ class ProvisioningTemplateTest < ActiveSupport::TestCase
     end
 
     test "#metadata should include OSes and kind" do
-      template = FactoryBot.build_stubbed(:provisioning_template, :operatingsystems => [
-                                            FactoryBot.create(:operatingsystem, :name => 'CentOS'),
-                                            FactoryBot.create(:operatingsystem, :name => 'CentOS'),
-                                            FactoryBot.create(:operatingsystem, :name => 'Fedora'),
+      template = FactoryBot.build_stubbed(:provisioning_template, operatingsystems: [
+                                            FactoryBot.create(:operatingsystem, name: 'CentOS'),
+                                            FactoryBot.create(:operatingsystem, name: 'CentOS'),
+                                            FactoryBot.create(:operatingsystem, name: 'Fedora'),
                                           ])
 
       lines = template.metadata.split("\n")


### PR DESCRIPTION
Extract Environment from TemplateCombination matrix as temporary solutin.
This should probably get dropped if favor of some better solution like direct set on hostgroup.

Though this will need to be reflected in foreman_puppet_enc plugin.

Extracted in: https://github.com/theforeman/foreman_puppet_enc/pull/98.