### PR TITLE
Fixes #31733 - drop UI for Environment assignment

### DIFF
--- a/app/helpers/provisioning_templates_helper.rb
+++ b/app/helpers/provisioning_templates_helper.rb
@@ -1,11 +1,6 @@
 module ProvisioningTemplatesHelper
   def combination(template)
-    template.template_combinations.map do |comb|
-      str = []
-      str << (comb.hostgroup_id.nil? ? _("None") : comb.hostgroup.to_s)
-      str << (comb.environment_id.nil? ? _("None") : comb.environment.to_s)
-      str.join(" / ")
-    end.to_sentence
+    template.template_combinations.map { |comb| comb.hostgroup.to_s }.to_sentence
   end
 
   def template_kind(template)
@@ -67,13 +62,11 @@ module ProvisioningTemplatesHelper
     alert(:class => 'alert-info', :header => 'How templates are determined',
           :text => ('<p>' + _("When editing a template, you must assign a list \
 of operating systems which this template can be used with. Optionally, you can \
-restrict a template to a list of host groups and/or environments.") + '</p>' +
+restrict a template to a list of host groups.") + '</p>' +
 '<p>' + _("When a Host requests a template (e.g. during provisioning), Foreman \
 will select the best match from the available templates of that type, in the \
 following order:") + '</p>' + '<ul>' +
-    '<li>' + _("Host group and Environment") + '</li>' +
-    '<li>' + _("Host group only") + '</li>' +
-    '<li>' + _("Environment only") + '</li>' +
+    '<li>' + _("Host group") + '</li>' +
     '<li>' + _("Operating system default") + '</li>' +
     '</ul>' +
     (_("The final entry, Operating System default, can be set by editing the %s page.") %

--- a/app/views/provisioning_templates/_combination.html.erb
+++ b/app/views/provisioning_templates/_combination.html.erb
@@ -1,5 +1,4 @@
 <div class="fields">
-  <%= select_f f, :hostgroup_id, Hostgroup.all, :id, :to_label, {:include_blank => true}, :label => _("Hostgroup") %>
-  <%= select_f f, :environment_id, Environment.all, :id, :name, {:include_blank => true},
-    :label => _("Environment"), :help_inline => link_to_remove_fields(_('Remove'), f, :title => _("Remove Combination")) %>
+  <%= select_f f, :hostgroup_id, Hostgroup.all, :id, :to_label, {:include_blank => true}, :label => _("Hostgroup"),
+        :help_inline => link_to_remove_fields(_('Remove'), f, :title => _("Remove Combination")) %>
 </div>

--- a/app/views/provisioning_templates/_combinations.html.erb
+++ b/app/views/provisioning_templates/_combinations.html.erb
@@ -1,4 +1,4 @@
-<%= field_set_tag _("Valid Host Group and Environment Combinations"), :id => "template_combination" do %>
+<%= field_set_tag _("Valid Host Groups"), :id => "template_combination" do %>
   <%= f.fields_for :template_combinations do |builder| %>
     <%= render 'provisioning_templates/combination', :f => builder %>
   <% end %>


### PR DESCRIPTION
Drop UI used for Environment assignment in Template combinations.

Extracted in https://github.com/theforeman/foreman_puppet_enc/pull/99