### PR TITLE
Fixes #32092 - add puppet safe guard

### DIFF
--- a/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
+++ b/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
@@ -17,7 +17,7 @@ This template accepts the following parameters:
 -%>
 <%
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
-  pm_set = @host.puppetmaster.empty? ? false : true
+  pm_set = @host.try(:puppetmaster).blank? ? false : true
   proxy_uri = host_param('http-proxy') ? "http://#{host_param('http-proxy')}:#{host_param('http-proxy-port')}" : nil
   puppet_enabled = pm_set || host_param_true?('force-puppet')
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy

--- a/app/views/unattended/provisioning_templates/finish/alterator_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/alterator_default_finish.erb
@@ -9,7 +9,7 @@ oses:
 #!/bin/sh
 
 <%= snippet 'fix_hosts' %>
-
+<% if @host.respond_to?(:puppetmaster) %>
 apt-get update >/dev/null 2>/dev/null
 apt-get -y install puppet >/dev/null 2>/dev/null
 
@@ -21,6 +21,12 @@ EOF
 /usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag --server <%= @host.puppetmaster %> --no-daemonize
 <%= snippet 'built' %>
 /sbin/chkconfig puppetd on
+
+<% else %>
+
+<%= snippet 'built' %>
+
+<% end %>
 
 <%= snippet 'schedule_reboot' -%>
 

--- a/app/views/unattended/provisioning_templates/finish/freebsd_(mfsbsd)_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/freebsd_(mfsbsd)_finish.erb
@@ -7,7 +7,7 @@ oses:
 %>
 <%
   # safemode renderer does not support unary negation
-  pm_set = @host.puppetmaster.empty? ? false : true
+  pm_set = @host.try(:puppetmaster).blank? ? false : true
   puppet_enabled = pm_set || host_param_true?('force-puppet')
   salt_enabled = host_param('salt_master') ? true : false
   proxy_string = host_param('http-proxy') ? "http://#{host_param('http-proxy')}:#{host_param('http-proxy-port')}" : ''

--- a/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
@@ -22,7 +22,7 @@ service network restart
 
 <%
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
-  pm_set = @host.puppetmaster.empty? ? false : true
+  pm_set = @host.try(:puppetmaster).blank? ? false : true
   puppet_enabled = pm_set || host_param_true?('force-puppet')
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy

--- a/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
@@ -8,7 +8,7 @@ oses:
 %>
 <%
   # safemode renderer does not support unary negation
-  pm_set = @host.puppetmaster.empty? ? false : true
+  pm_set = @host.try(:puppetmaster).blank? ? false : true
   puppet_enabled = pm_set || host_param_true?('force-puppet')
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy

--- a/app/views/unattended/provisioning_templates/finish/windows_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/windows_default_finish.erb
@@ -27,8 +27,8 @@ params:
 %>
 <%
   # safemode renderer does not support unary negation
-  pm_set = @host.puppetmaster.empty? ? false : true
-  puppet_enabled = pm_set || host_param('force-puppet') && host_param('force-puppet') == 'true'
+  pm_set = @host.try(:puppetmaster).blank? ? false : true
+  puppet_enabled = pm_set || host_param_true?('force-puppet')
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
 %>

--- a/app/views/unattended/provisioning_templates/provision/autoyast_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/autoyast_default.erb
@@ -7,7 +7,7 @@ oses:
 -%>
 <%
   # safemode renderer does not support unary negation
-  pm_set = @host.puppetmaster.empty? ? false : true
+  pm_set = @host.try(:puppetmaster).blank? ? false : true
   puppet_enabled = pm_set || host_param_true?('force-puppet')
   salt_enabled = host_param('salt_master') ? true : false
   os_major = @host.operatingsystem.major.to_i

--- a/app/views/unattended/provisioning_templates/provision/autoyast_sles_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/autoyast_sles_default.erb
@@ -9,7 +9,7 @@ oses:
   os_major = @host.operatingsystem.major.to_i
   os_minor = @host.operatingsystem.minor.to_i
   # safemode renderer does not support unary negation
-  pm_set = @host.puppetmaster.empty? ? false : true
+  pm_set = @host.try(:puppetmaster).blank? ? false : true
   aio_enabled = host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppet5')
   puppet_enabled = pm_set || host_param_true?('force-puppet')
   salt_enabled = host_param('salt_master') ? true : false

--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -44,7 +44,7 @@ https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/pe
   os_minor = @host.operatingsystem.minor.to_i
   realm_compatible = (@host.operatingsystem.name == 'Fedora' && os_major >= 20) || (rhel_compatible && os_major >= 7)
   # safemode renderer does not support unary negation
-  pm_set = @host.puppetmaster.empty? ? false : true
+  pm_set = @host.try(:puppetmaster).blank? ? false : true
   proxy_uri = host_param('http-proxy') ? "http://#{host_param('http-proxy')}:#{host_param('http-proxy-port')}" : nil
   proxy_string = proxy_uri ? " --proxy=#{proxy_uri}" : ''
   puppet_enabled = pm_set || host_param_true?('force-puppet')

--- a/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
@@ -5,6 +5,7 @@ model: ProvisioningTemplate
 snippet: true
 -%>
 <%
+if @host.puppetmaster
   os_family = @host.operatingsystem.family
   os_name   = @host.operatingsystem.name
 
@@ -47,3 +48,4 @@ ca_server       = <%= @host.puppet_ca_server %>
 certname        = <%= @host.certname %>
 environment     = <%= @host.environment %>
 server          = <%= @host.puppetmaster %>
+<%- end -%>

--- a/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
@@ -6,6 +6,7 @@ description: this snippet will configure the Puppet agent
 snippet: true
 -%>
 <%
+if @host.respond_to?(:puppetmaster)
 os_family = @host.operatingsystem.family
 os_major  = @host.operatingsystem.major.to_i
 os_name   = @host.operatingsystem.name
@@ -156,5 +157,6 @@ export FACTER_is_installer=true
 <% end -%>
 <% if @host.provision_method == 'image' -%>
 <%= bin_path %>/puppet resource service puppet ensure=running
+<% end -%>
 <% end -%>
 <% end -%>

--- a/app/views/unattended/provisioning_templates/user_data/autoyast_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/autoyast_default_user_data.erb
@@ -8,7 +8,7 @@ oses:
 -%>
 <%
   # safemode renderer does not support unary negation
-  pm_set = @host.puppetmaster.empty? ? false : true
+  pm_set = @host.try(:puppetmaster).blank? ? false : true
   puppet_enabled = pm_set || host_param_true?('force-puppet')
   salt_enabled = host_param('salt_master') ? true : false
 -%>

--- a/app/views/unattended/provisioning_templates/user_data/kickstart_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/kickstart_default_user_data.erb
@@ -9,7 +9,7 @@ oses:
 <%
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
   # safemode renderer does not support unary negation
-  pm_set = @host.puppetmaster.empty? ? false : true
+  pm_set = @host.try(:puppetmaster).blank? ? false : true
   puppet_enabled = pm_set || host_param_true?('force-puppet')
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy

--- a/app/views/unattended/provisioning_templates/user_data/preseed_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/preseed_default_user_data.erb
@@ -13,7 +13,7 @@ oses:
 
 <%
   # safemode renderer does not support unary negation
-  pm_set = @host.puppetmaster.empty? ? false : true
+  pm_set = @host.try(:puppetmaster).blank? ? false : true
   proxy_uri = host_param('http-proxy') ? "http://#{host_param('http-proxy')}:#{host_param('http-proxy-port')}" : nil
   puppet_enabled = pm_set || host_param_true?('force-puppet')
   salt_enabled = host_param('salt_master') ? true : false

--- a/app/views/unattended/provisioning_templates/user_data/userdata_default.erb
+++ b/app/views/unattended/provisioning_templates/user_data/userdata_default.erb
@@ -19,7 +19,7 @@ This template accepts the following parameters:
   ssh_pwauth = host_param('ssh_pwauth') ? host_param_true?('ssh_pwauth') : !host_param('ssh_authorized_keys')
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
   # safemode renderer does not support unary negation
-  pm_set = @host.puppetmaster.empty? ? false : true
+  pm_set = @host.try(:puppetmaster).blank? ? false : true
   puppet_enabled = pm_set || host_param_true?('force-puppet')
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy


### PR DESCRIPTION
Adds safe guard to all plugin templates to check whether the puppet
plugin is present. Force puppet disabled if plugin not present.
