### PR TITLE
Fixes #31369 - drop environment fixtures

### DIFF
--- a/test/fixtures/environments.yml
+++ b/test/fixtures/environments.yml
@@ -1,9 +1,0 @@
----
-production:
-  name: production
-
-global_puppetmaster:
-  name: global_puppetmaster
-
-testing:
-  name: testing

--- a/test/fixtures/filterings.yml
+++ b/test/fixtures/filterings.yml
@@ -23,21 +23,6 @@ manager_2_2:
 manager_2_3:
   filter: manager_2
   permission: destroy_authenticators
-manager_3_0:
-  filter: manager_3
-  permission: view_environments
-manager_3_1:
-  filter: manager_3
-  permission: create_environments
-manager_3_2:
-  filter: manager_3
-  permission: edit_environments
-manager_3_3:
-  filter: manager_3
-  permission: destroy_environments
-manager_3_4:
-  filter: manager_3
-  permission: import_environments
 manager_5_0:
   filter: manager_5
   permission: view_domains
@@ -290,9 +275,6 @@ viewer_4_1:
 viewer_5_0:
   filter: viewer_5
   permission: view_domains
-viewer_6_0:
-  filter: viewer_6
-  permission: view_environments
 viewer_8_0:
   filter: viewer_8
   permission: view_facts

--- a/test/fixtures/filters.yml
+++ b/test/fixtures/filters.yml
@@ -3,8 +3,6 @@ manager_1:
   role_id: 1
 manager_2:
   role_id: 1
-manager_3:
-  role_id: 1
 manager_5:
   role_id: 1
 manager_6:
@@ -60,8 +58,6 @@ viewer_3:
 viewer_4:
   role_id: 5
 viewer_5:
-  role_id: 5
-viewer_6:
   role_id: 5
 viewer_8:
   role_id: 5

--- a/test/fixtures/permissions.yml
+++ b/test/fixtures/permissions.yml
@@ -169,31 +169,6 @@ destroy_realms:
   resource_type: Realm
   created_at: "2013-12-04 08:41:04.648794"
   updated_at: "2013-12-04 08:41:04.648794"
-view_environments:
-  name: view_environments
-  resource_type: Environment
-  created_at: "2013-12-04 08:41:04.623403"
-  updated_at: "2013-12-04 08:41:04.623403"
-create_environments:
-  name: create_environments
-  resource_type: Environment
-  created_at: "2013-12-04 08:41:04.631791"
-  updated_at: "2013-12-04 08:41:04.631791"
-edit_environments:
-  name: edit_environments
-  resource_type: Environment
-  created_at: "2013-12-04 08:41:04.640671"
-  updated_at: "2013-12-04 08:41:04.640671"
-destroy_environments:
-  name: destroy_environments
-  resource_type: Environment
-  created_at: "2013-12-04 08:41:04.648794"
-  updated_at: "2013-12-04 08:41:04.648794"
-import_environments:
-  name: import_environments
-  resource_type: Environment
-  created_at: "2013-12-04 08:41:04.656654"
-  updated_at: "2013-12-04 08:41:04.656654"
 view_globals:
   name: view_globals
   resource_type: CommonParameter


### PR DESCRIPTION
This is completely dropped, in plugin we use factories instead.